### PR TITLE
Make QtKnobs a QML plugin

### DIFF
--- a/Knobs.pro
+++ b/Knobs.pro
@@ -25,12 +25,10 @@
 #************************************************************************************/
 
 TEMPLATE = lib
-CONFIG += plugin
-
 QT += qml quick
 
-DESTDIR = Knobs
-TARGET  = QtKnobs
+uri = Knobs
+include(QtKnobs/plugin.pri)
 
 OBJECTS_DIR = tmp
 MOC_DIR = tmp
@@ -44,8 +42,6 @@ SOURCES += QtKnobs/styles/piestyle.cpp \
     QtKnobs/common/dial.cpp
 
 CONFIG += c++11
-
-unix:!macx: QMAKE_POST_LINK=strip $$PWD/Knobs/$(TARGET)
 
 RESOURCES += QtKnobs/qml.qrc
 
@@ -62,7 +58,6 @@ HEADERS += \
 DISTFILES += \
     QtKnobs/examples/main.qml
 
+QML_INFRA_FILES = Knobs/qmldir
 
-
-
-
+include(QtKnobs/deployment.pri)

--- a/Knobs.pro
+++ b/Knobs.pro
@@ -27,7 +27,7 @@
 TEMPLATE = lib
 QT += qml quick
 
-uri = Knobs
+uri = QtKnobs
 include(QtKnobs/plugin.pri)
 
 OBJECTS_DIR = tmp

--- a/Knobs/qmldir
+++ b/Knobs/qmldir
@@ -1,2 +1,2 @@
 module Knobs
-plugin QtKnobs
+plugin knobsplugin

--- a/Knobs/qmldir
+++ b/Knobs/qmldir
@@ -1,2 +1,2 @@
-module Knobs
-plugin knobsplugin
+module QtKnobs
+plugin qtknobsplugin

--- a/Knobs/qmldir
+++ b/Knobs/qmldir
@@ -1,2 +1,3 @@
 module QtKnobs
 plugin qtknobsplugin
+classname QtKnobsPlugin

--- a/QtKnobs/common/component.h
+++ b/QtKnobs/common/component.h
@@ -49,7 +49,7 @@ public:
             return "import QtQuick 2.0\nText{anchors.centerIn:parent}";
         } else if(type=="ArcStyle"||type=="PieStyle"||type=="NeedleStyle") {
             return "import QtQuick 2.0"
-                    "\nimport Knobs 1.1"
+                    "\nimport QtKnobs 1.1"
                     "\n"+type.toLatin1()+"{"
                     "\nid:chunk"
                     "\nanchors.fill:parent"

--- a/QtKnobs/deployment.pri
+++ b/QtKnobs/deployment.pri
@@ -1,0 +1,63 @@
+TARGETPATH = $$replace(uri, \\., /)
+DESTDIR = $$OUT_PWD/imports/$$TARGETPATH
+
+isEmpty(PLUGIN_VERSION): PLUGIN_VERSION = 1.0
+
+# ========== copy additional files ==========
+copyqmlinfra.input = QML_INFRA_FILES
+copyqmlinfra.output = $$OUT_PWD/../../imports/$$TARGETPATH/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
+!win32: copyqmlinfra.commands = $$QMAKE_MKDIR $$shell_path($$dirname(copyqmlinfra.output)) $$escape_expand(\n\t)
+copyqmlinfra.commands +=  $$QMAKE_COPY ${QMAKE_FILE_IN} ${QMAKE_FILE_OUT}
+copyqmlinfra.CONFIG += no_link no_clean
+copyqmlinfra.variable_out = PRE_TARGETDEPS
+QMAKE_EXTRA_COMPILERS += copyqmlinfra
+
+copyqmldesigner.input = QML_DESIGNER_FILES
+copyqmldesigner.output = $$OUT_PWD/../../imports/$$TARGETPATH/designer/
+copyqmldesigner.commands = $(COPY_DIR) ${QMAKE_FILE_IN} $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/designer/)
+copyqmldesigner.CONFIG += no_link no_clean
+copyqmldesigner.variable_out = PRE_TARGETDEPS
+QMAKE_EXTRA_COMPILERS += copyqmldesigner
+
+copyqmlpropertyeditor.input = QML_PROPERTY_EDITOR_FILES
+copyqmlpropertyeditor.output = $$OUT_PWD/../../imports/$$TARGETPATH/propertyEditorQmlSources/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
+!win32: copyqmlpropertyeditor.commands = $$QMAKE_MKDIR $$shell_path($$dirname(copyqmlpropertyeditor.output)) $$escape_expand(\n\t)
+copyqmlpropertyeditor.commands += $$QMAKE_COPY ${QMAKE_FILE_IN} ${QMAKE_FILE_OUT}
+copyqmlpropertyeditor.CONFIG += no_link no_clean
+copyqmlpropertyeditor.variable_out = PRE_TARGETDEPS
+QMAKE_EXTRA_COMPILERS += copyqmlpropertyeditor
+
+win32: QMAKE_DEL_FILE = del /q /f
+!win32:QMAKE_DEL_FILE = rm -r -f
+QMAKE_CLEAN += $$OUT_PWD/imports/$$TARGETPATH/
+
+# ========== install additional files ==========
+!android: !ios: !debug: {
+    dumppluginqmltypes.CONFIG = no_files no_path
+    dumppluginqmltypes.commands = $$dirname(QMAKE_QMAKE)/qmlplugindump "$$uri $$PLUGIN_VERSION $$shell_path($$OUT_PWD/../../imports/) > $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/plugins.qmltypes)"
+    INSTALLS += dumppluginqmltypes
+
+    copypluginqmltypes.CONFIG = no_files no_path
+    !win32: copypluginqmltypes.commands = $$QMAKE_MKDIR $$shell_path($$[QT_INSTALL_QML]/$$TARGETPATH/) $$escape_expand(\n\t)
+    copypluginqmltypes.commands += $$QMAKE_COPY $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/plugins.qmltypes) $$shell_path($$[QT_INSTALL_QML]/$$TARGETPATH/plugins.qmltypes)
+    INSTALLS += copypluginqmltypes
+}
+
+copyqmlinfra_install.files = $$QML_INFRA_FILES
+copyqmlinfra_install.path = $$[QT_INSTALL_QML]/$$TARGETPATH
+INSTALLS += copyqmlinfra_install
+
+copyqmldesigner_install.files = $$QML_DESIGNER_FILES
+copyqmldesigner_install.path = $$[QT_INSTALL_QML]/$$TARGETPATH
+INSTALLS += copyqmldesigner_install
+
+copyqmlpropertyeditor_install.files = $$QML_PROPERTY_EDITOR_FILES
+copyqmlpropertyeditor_install.path = $$QTCREATOR_INSTALL_DIR/share/qtcreator/qmldesigner/propertyEditorQmlSources/$$TARGETPATH
+INSTALLS += copyqmlpropertyeditor_install
+
+target.path = $$[QT_INSTALL_QML]/$$TARGETPATH
+
+INSTALLS += target
+
+
+OTHER_FILES += $$QML_INFRA_FILES $$QML_DESIGNER_FILES $$QML_PROPERTY_EDITOR_FILES

--- a/QtKnobs/deployment.pri
+++ b/QtKnobs/deployment.pri
@@ -5,7 +5,7 @@ isEmpty(PLUGIN_VERSION): PLUGIN_VERSION = 1.0
 
 # ========== copy additional files ==========
 copyqmlinfra.input = QML_INFRA_FILES
-copyqmlinfra.output = $$OUT_PWD/../../imports/$$TARGETPATH/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
+copyqmlinfra.output = $$OUT_PWD/imports/$$TARGETPATH/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
 !win32: copyqmlinfra.commands = $$QMAKE_MKDIR $$shell_path($$dirname(copyqmlinfra.output)) $$escape_expand(\n\t)
 copyqmlinfra.commands +=  $$QMAKE_COPY ${QMAKE_FILE_IN} ${QMAKE_FILE_OUT}
 copyqmlinfra.CONFIG += no_link no_clean
@@ -13,14 +13,14 @@ copyqmlinfra.variable_out = PRE_TARGETDEPS
 QMAKE_EXTRA_COMPILERS += copyqmlinfra
 
 copyqmldesigner.input = QML_DESIGNER_FILES
-copyqmldesigner.output = $$OUT_PWD/../../imports/$$TARGETPATH/designer/
-copyqmldesigner.commands = $(COPY_DIR) ${QMAKE_FILE_IN} $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/designer/)
+copyqmldesigner.output = $$OUT_PWD/imports/$$TARGETPATH/designer/
+copyqmldesigner.commands = $(COPY_DIR) ${QMAKE_FILE_IN} $$shell_path($$OUT_PWD/imports/$$TARGETPATH/designer/)
 copyqmldesigner.CONFIG += no_link no_clean
 copyqmldesigner.variable_out = PRE_TARGETDEPS
 QMAKE_EXTRA_COMPILERS += copyqmldesigner
 
 copyqmlpropertyeditor.input = QML_PROPERTY_EDITOR_FILES
-copyqmlpropertyeditor.output = $$OUT_PWD/../../imports/$$TARGETPATH/propertyEditorQmlSources/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
+copyqmlpropertyeditor.output = $$OUT_PWD/imports/$$TARGETPATH/propertyEditorQmlSources/${QMAKE_FILE_IN_BASE}${QMAKE_FILE_EXT}
 !win32: copyqmlpropertyeditor.commands = $$QMAKE_MKDIR $$shell_path($$dirname(copyqmlpropertyeditor.output)) $$escape_expand(\n\t)
 copyqmlpropertyeditor.commands += $$QMAKE_COPY ${QMAKE_FILE_IN} ${QMAKE_FILE_OUT}
 copyqmlpropertyeditor.CONFIG += no_link no_clean
@@ -34,12 +34,12 @@ QMAKE_CLEAN += $$OUT_PWD/imports/$$TARGETPATH/
 # ========== install additional files ==========
 !android: !ios: !debug: {
     dumppluginqmltypes.CONFIG = no_files no_path
-    dumppluginqmltypes.commands = $$dirname(QMAKE_QMAKE)/qmlplugindump "$$uri $$PLUGIN_VERSION $$shell_path($$OUT_PWD/../../imports/) > $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/plugins.qmltypes)"
+    dumppluginqmltypes.commands = $$dirname(QMAKE_QMAKE)/qmlplugindump "$$uri $$PLUGIN_VERSION $$shell_path($$OUT_PWD/imports/) > $$shell_path($$OUT_PWD/imports/$$TARGETPATH/plugins.qmltypes)"
     INSTALLS += dumppluginqmltypes
 
     copypluginqmltypes.CONFIG = no_files no_path
     !win32: copypluginqmltypes.commands = $$QMAKE_MKDIR $$shell_path($$[QT_INSTALL_QML]/$$TARGETPATH/) $$escape_expand(\n\t)
-    copypluginqmltypes.commands += $$QMAKE_COPY $$shell_path($$OUT_PWD/../../imports/$$TARGETPATH/plugins.qmltypes) $$shell_path($$[QT_INSTALL_QML]/$$TARGETPATH/plugins.qmltypes)
+    copypluginqmltypes.commands += $$QMAKE_COPY $$shell_path($$OUT_PWD/imports/$$TARGETPATH/plugins.qmltypes) $$shell_path($$[QT_INSTALL_QML]/$$TARGETPATH/plugins.qmltypes)
     INSTALLS += copypluginqmltypes
 }
 

--- a/QtKnobs/examples/main.qml
+++ b/QtKnobs/examples/main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Knobs 1.0
+import QtKnobs 1.0
 import QtQuick.Controls 1.2
 
 Rectangle {

--- a/QtKnobs/plugin.pri
+++ b/QtKnobs/plugin.pri
@@ -1,0 +1,4 @@
+CONFIG += qt plugin
+CONFIG -= android_install
+TARGET = $$qtLibraryTarget($$lower($$replace(uri, \\., ))plugin)
+QMAKE_MOC_OPTIONS += -Muri=$$uri

--- a/QtKnobs/plugin/qtknobsplugin.cpp
+++ b/QtKnobs/plugin/qtknobsplugin.cpp
@@ -8,7 +8,7 @@ QtKnobsPlugin::~QtKnobsPlugin()
 
 void QtKnobsPlugin::registerTypes(const char *uri)
 {
-    Q_ASSERT(uri == QLatin1String("Knobs"));
+    Q_ASSERT(uri == QLatin1String("QtKnobs"));
     qmlRegisterType<Knob>(uri, 1, 0, "Knob");
     qmlRegisterType<ArcStyle>(uri, 1, 1, "ArcStyle");
     qmlRegisterType<PieStyle>(uri, 1, 1, "PieStyle");

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The compiled library (libQtKnobs.so on .nix systems) would be in directory **Kno
   
   ```
   import QtQuick 2.0
-  import Knobs 1.0
+  import QtKnobs 1.0
   Knob {
     id: myKnob
   }

--- a/README.md
+++ b/README.md
@@ -45,33 +45,11 @@ Qt >= 5.3
 
 #Building
 * Clone
-* Run qmake && make
+* Run qmake && make && make install
 
 The compiled library (libQtKnobs.so on .nix systems) would be in directory **Knobs** with **qmldir**.
 
-#Use
-Copy directory **Knobs** to your project location and include in it your .pro file.
-For eg:
-```
-unix:!macx: LIBS += -L$$PWD/Knobs/ -lQtKnobs
-
-INCLUDEPATH += $$PWD/Knobs
-DEPENDPATH += $$PWD/Knobs
-```
-Then to make the engine to search for this module, add the path where the **Knobs** directory is using *addImportPath*. 
-For eg. If the directory **Knobs** is at location */home/ashish/KnobsTest* then,
-```
-QQuickView view;
-view.engine()->addImportPath("/home/ashish/KnobsTest");
-view.show();
-```
-
-Additionally, to make QtCreator aware of it (and to get rid of the annoying **QML module not found** during import) add the path in .pro file,
-```
-QML_IMPORT_PATH = /home/ashish/KnobsTest
-```
-
-#Examples
+#Use & Examples
 
 * A simple Knob:
   


### PR DESCRIPTION
This patch makes a real QML plugin of QtKnobs. Fully installable and usable just by importing QtKnobs in the QML file.

Tested on Linux and Android. Should also work on every other os. If you want to add QtKnobs to the designer please contact me.